### PR TITLE
Fix broken link

### DIFF
--- a/Guides/Installing ChrUbuntu.md
+++ b/Guides/Installing ChrUbuntu.md
@@ -120,6 +120,6 @@ your installation from corruption due to unexpected power loss. Read more on the
 **Further Reading**
   * [Common ChrUbuntu Fixes](https://github.com/iantrich/ChrUbuntu-Guides#fixes)
   * [ChrUbuntu Tips](https://github.com/iantrich/ChrUbuntu-Guides#tips)
-  * [Not an Ubuntu fan? Installing a different flavor of Linux](https://github.com/iantrich/ChrUbuntu-Guides/edit/master/Guides/Installing%20a%20custom%20distro.md)
+  * [Not an Ubuntu fan? Installing a different flavor of Linux](https://github.com/iantrich/ChrUbuntu-Guides/blob/master/Guides/Installing%20a%20custom%20distro.md)
 
 


### PR DESCRIPTION
When someone without write access to the repository would attempt to navigate to [the previous link](https://github.com/iantrich/ChrUbuntu-Guides/edit/master/Guides/Installing%20a%20custom%20distro.md), they'd be greeted by a page informing them that they'll need to fork the repository to make changes. If they're not logged in, they'd be forced to login to GitHub. This fixes that.
